### PR TITLE
Integrate Spring Cloud Config and update dependencies

### DIFF
--- a/mj-ecom-micorservices/order-service/pom.xml
+++ b/mj-ecom-micorservices/order-service/pom.xml
@@ -28,6 +28,7 @@
     </scm>
     <properties>
         <java.version>17</java.version>
+        <spring-cloud.version>2025.0.0</spring-cloud.version>
     </properties>
     <dependencies>
         <dependency>
@@ -58,8 +59,30 @@
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bus-amqp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
     </dependencies>
-
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>

--- a/mj-ecom-micorservices/order-service/src/main/resources/application.yml
+++ b/mj-ecom-micorservices/order-service/src/main/resources/application.yml
@@ -2,31 +2,5 @@ spring:
   application:
     name: order-service
 
-  datasource:
-    url: jdbc:postgresql://localhost:5432/order
-    username: ${POSTGRES_USERNAME}
-    password: ${POSTGRES_PASSWORD}
-    driver-class-name: org.postgresql.Driver
-
-  jpa:
-    database: postgresql
-    show-sql: true
-    hibernate:
-      ddl-auto: update
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
-
-#  h2:
-#    console:
-#      enabled: true
-
-#  datasource:
-#    url: jdbc:h2:mem:test
-
-#  jpa:
-#    show-sql: true
-#    hibernate:
-#      ddl-auto: create
-
-
-server:
-  port: 8084
+  config:
+    import: optional:configserver:http://localhost:8081


### PR DESCRIPTION
Added Spring Cloud Config, Bus AMQP, and Actuator dependencies to the order-service. Updated application.yml to import configuration from a config server and removed local datasource and JPA settings to centralize configuration management.