### PR TITLE
Add Eureka client dependency to user-service

### DIFF
--- a/mj-ecom-micorservices/user-service/pom.xml
+++ b/mj-ecom-micorservices/user-service/pom.xml
@@ -62,6 +62,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Included spring-cloud-starter-netflix-eureka-client in the user-service pom.xml to enable service registration and discovery with Eureka.