### PR TITLE
Added product stock update endpoints and integrated with order

### DIFF
--- a/mj-ecom-micorservices/order-service/pom.xml
+++ b/mj-ecom-micorservices/order-service/pom.xml
@@ -138,6 +138,25 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/mj-ecom-micorservices/order-service/src/main/java/mj/ecom/orderservice/clients/ProductServiceClient.java
+++ b/mj-ecom-micorservices/order-service/src/main/java/mj/ecom/orderservice/clients/ProductServiceClient.java
@@ -3,12 +3,18 @@ package mj.ecom.orderservice.clients;
 import mj.ecom.orderservice.dto.ProductResponse;
 import mj.ecom.orderservice.dto.UserResponse;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PatchExchange;
+import org.springframework.web.service.annotation.PutExchange;
 
 @HttpExchange
 public interface ProductServiceClient {
     @GetExchange("/api/products/{id}")
     ProductResponse getAllProductById(@PathVariable String id);
 
+    @PatchExchange("/api/products/{productId}/reduce-stock")
+    void reduceProductStock(@PathVariable String productId, @RequestParam int quantity, @RequestParam(required = false) String transaction);
 }

--- a/mj-ecom-micorservices/order-service/src/main/java/mj/ecom/orderservice/clients/RestClientConfig.java
+++ b/mj-ecom-micorservices/order-service/src/main/java/mj/ecom/orderservice/clients/RestClientConfig.java
@@ -3,6 +3,7 @@ package mj.ecom.orderservice.clients;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.propagation.Propagator;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
@@ -11,14 +12,12 @@ import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.web.client.RestClient;
 
 @Configuration
+@RequiredArgsConstructor
 public class RestClientConfig {
 
-    @Autowired(required = false)
-    private ObservationRegistry observationRegistry;
-    @Autowired(required = false)
-    private Tracer tracer;
-    @Autowired(required = false)
-    private Propagator propagator;
+    private final ObservationRegistry observationRegistry;
+    private final Tracer tracer;
+    private final Propagator propagator;
 
     @Bean
     @LoadBalanced

--- a/mj-ecom-micorservices/product-service/pom.xml
+++ b/mj-ecom-micorservices/product-service/pom.xml
@@ -130,6 +130,25 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/mj-ecom-micorservices/product-service/src/main/java/mj/ecom/productservice/controller/ProductController.java
+++ b/mj-ecom-micorservices/product-service/src/main/java/mj/ecom/productservice/controller/ProductController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mj.ecom.productservice.dto.ProductRequest;
 import mj.ecom.productservice.dto.ProductResponse;
+import mj.ecom.productservice.model.Product;
 import mj.ecom.productservice.service.ProductService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -51,6 +52,21 @@ public class ProductController {
         return productService.updateProduct(id, productRequest)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PatchMapping("/{productId}/reduce-stock")
+    public ResponseEntity<String> reduceStock(@PathVariable String productId, @RequestParam int quantity, @RequestParam(required = false) String transaction) {
+        log.info("Reducing Stock {} and reducing quantity request received from {}", productId, transaction);
+        return productService.reduceStock(productId, quantity)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.ok("Error while updating stock quantity of product" + productId));
+    }
+
+    @PatchMapping("/{productId}/add-stock")
+    public ResponseEntity<String> addStock(@PathVariable String productId, @RequestParam int quantity) {
+        return productService.addStock(productId, quantity)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.ok("Error while updating stock quantity of product" + productId));
     }
 
     @DeleteMapping("/{id}")

--- a/mj-ecom-micorservices/product-service/src/main/java/mj/ecom/productservice/service/ProductService.java
+++ b/mj-ecom-micorservices/product-service/src/main/java/mj/ecom/productservice/service/ProductService.java
@@ -46,6 +46,11 @@ public class ProductService {
         product.setStockQuantity(productRequest.getStockQuantity());
     }
 
+    private void patchProductFromRequest(Product product, int quantity, String transaction) {
+        if (transaction.equals("reduceStock")) product.setStockQuantity(product.getStockQuantity() - quantity);
+        else product.setStockQuantity(product.getStockQuantity() + quantity);
+    }
+
     public Optional<ProductResponse> updateProduct(Long id, ProductRequest productRequest) {
         return productRepository.findById(id)
                 .map(existingProduct -> {
@@ -79,5 +84,23 @@ public class ProductService {
     public Optional<ProductResponse> getAllProductById(String id) {
         return productRepository.findByIdAndActiveTrue(Long.valueOf(id))
                 .map(this::mapToProductResponse);
+    }
+
+    public Optional<String> reduceStock(String productId, int quantity) {
+        return productRepository.findById(Long.valueOf(productId))
+                .map(existingProduct -> {
+                    patchProductFromRequest(existingProduct, quantity, "reduceStock");
+                    Product savedProduct = productRepository.save(existingProduct);
+                    return "Updated Quantity for product" + productId + " and total available quantity" + savedProduct.getStockQuantity();
+                });
+    }
+
+    public Optional<String> addStock(String productId, int quantity) {
+        return productRepository.findById(Long.valueOf(productId))
+                .map(existingProduct -> {
+                    patchProductFromRequest(existingProduct, quantity, "addStock");
+                    Product savedProduct = productRepository.save(existingProduct);
+                    return "Updated Quantity for product" + productId + " and total available quantity" + savedProduct.getStockQuantity();
+                });
     }
 }


### PR DESCRIPTION
Introduced PATCH endpoints in ProductController for reducing and adding product stock. Implemented corresponding methods in ProductService to handle stock updates. Updated OrderService to call ProductServiceClient and reduce product stock upon successful order creation. Added jacoco-maven-plugin for code coverage reporting in both order-service and product-service. Refactored RestClientConfig to use constructor injection with Lombok's @RequiredArgsConstructor.